### PR TITLE
Enable options that allow the higlass viewer to go full screen.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import * as hglib from 'higlass';
 import demo from './data/demo.js'
 
 import CTracksComp from 'components/CTracksComp';
+import ResilientData from 'components/CTracksComp/ResilientData'
 
 //import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
@@ -15,6 +16,7 @@ class App extends React.Component {
   constructor (props) {
     super(props);
     if (props.match.params.prefix) hamradio.prefix(props.match.params.prefix)
+    ResilientData.initialize(`cTracks/${props.match.params.prefix || ''}`) // gets it to listen to the events and store critical data, also initializes the data to store what's in SessionStorage
 
     this.state = {
       chromInfo: null,
@@ -31,7 +33,7 @@ class App extends React.Component {
     hglib.ChromosomeInfo('http://higlass.io/api/v1/chrom-sizes/?id=Ajn_ttUUQbqgtOD4nOt-IA')
       .then(info => this.setState({chromInfo: info}))
 
-    if (this.state.uid === 'demo')
+    if (this.state.uid === 'demo' && !ResilientData.servers().length)
       demo()
 
     hamradio.publish('ready/cTracks')

--- a/src/data/demo.js
+++ b/src/data/demo.js
@@ -61,6 +61,12 @@ let demoTracks = [
 export default function () {
   hamradio.publish('cTracks/variants', testCNVTable)
   hamradio.publish('server/add', {name: 'Demo', api: server})
+  hamradio.publish('tools', {
+    zoom: true,
+    servers: true,
+    urls: true,
+    tracks: true
+  })
   demoTracks.forEach((trackDiffs, i) => {
     let track = tracks.track(trackDiffs, tracks.horizontalPointOptions(trackDiffs.options))
     hamradio.publish('track/add', {

--- a/src/node_modules/components/CTracksComp/CNVTable.css
+++ b/src/node_modules/components/CTracksComp/CNVTable.css
@@ -1,8 +1,9 @@
 
 .CNVTable {
+  padding: 10px;
   margin: 10px;
-	/*margin-left: 50px;*/
-  /*padding-top: 10px;*/
+  border: 1px solid #ccc;
+  border-radius: 5px;
 }
 
 .ReactTable .rt-thead {

--- a/src/node_modules/components/CTracksComp/CNVTable.js
+++ b/src/node_modules/components/CTracksComp/CNVTable.js
@@ -77,16 +77,28 @@ class CNVTable extends React.Component {
   constructor (props) {
     super(props);
     this.state = {
+      HighlightIDs: [],
+      selection: [],
       TableData: [],
       TableColumns: [],
-      HighlightIDs: [],
-      selection: []
-    };
-    this.viewport = [
-      [1, 0],
-      [1, 249250621]
-    ]
+      viewport: [
+        [1, 0],
+        [1, 249250621]
+      ]
+    }
     this.subscriptions = this.makeSubscriptions()
+  }
+
+  static getDerivedStateFromProps(newProps, prevState) {
+    console.log(newProps)
+    let TableData = GenerateTableData(newProps.variants)
+
+    return {
+      HighlightIDs: computeHighlights(TableData, prevState.viewport),
+      selection: [],
+      TableData,
+      TableColumns: GenerateTableColumns(TableData)
+    }
   }
 
   componentWillUnmount() {
@@ -101,23 +113,11 @@ class CNVTable extends React.Component {
       hamradio.subscribe(
         'viewport/moved',
         (name, viewport) => {
-          this.viewport = viewport
           this.setState({
-            HighlightIDs: computeHighlights(this.state.TableData, this.viewport)
+            viewport,
+            HighlightIDs: computeHighlights(this.state.TableData, viewport)
           })
-        }),
-      hamradio.subscribe(
-        'cTracks/variants',
-        (name, variants) => {
-          let TableData = GenerateTableData(variants)
-          this.setState({
-            HighlightIDs: computeHighlights(TableData, this.viewport),
-            selection: [],
-            TableData,
-            TableColumns: GenerateTableColumns(TableData)
-          })
-        }
-      )
+        })
     ]
   }
 

--- a/src/node_modules/components/CTracksComp/CNVTable.js
+++ b/src/node_modules/components/CTracksComp/CNVTable.js
@@ -195,32 +195,30 @@ class CNVTable extends React.Component {
 
 		return TableData && TableColumns && TableData.length > 0 && TableColumns.length > 0
       ? (
-          <div className = "RightBox">
-            <div>
-              <CheckboxTable
-                ref={(r)=>this.checkboxTable=r}
-                data={TableData}
-                columns={TableColumns}
-                defaultPageSize={this.state.TableData.length}
-                style={{
-                  height: "400px"
-                }}
-                className="-striped -highlight"
-                showPagination={false}
-                {...checkboxProps}
-                getTrProps={(state, rowInfo) => {
-                  const props = {
-                    onClick: e => {
-                      return this.handleRowClick(rowInfo);
-                    },
-                    style: {
-                      background: this.handleRowBackground(rowInfo),
-                    },
-                  };
-                  return props;
-                }}
-              />
-            </div>
+          <div className = "Box">
+            <CheckboxTable
+              ref={(r)=>this.checkboxTable=r}
+              data={TableData}
+              columns={TableColumns}
+              defaultPageSize={this.state.TableData.length}
+              style={{
+                height: "400px"
+              }}
+              className="-striped -highlight"
+              showPagination={false}
+              {...checkboxProps}
+              getTrProps={(state, rowInfo) => {
+                const props = {
+                  onClick: e => {
+                    return this.handleRowClick(rowInfo);
+                  },
+                  style: {
+                    background: this.handleRowBackground(rowInfo),
+                  },
+                };
+                return props;
+              }}
+            />
           </div>
   		  )
       : null

--- a/src/node_modules/components/CTracksComp/CNVTable.js
+++ b/src/node_modules/components/CTracksComp/CNVTable.js
@@ -45,6 +45,7 @@ function computeHighlights(data, viewport) {
 // generate data with ID information
 function GenerateTableData(inputData)
 {
+  if (!inputData.length) return []
   var Keys = Object.keys(inputData[0]);
   const data = inputData.map((item)=>{
     const _id = 'chr' + item[Keys[0]] + '-' + item[Keys[1]];
@@ -59,6 +60,7 @@ function GenerateTableData(inputData)
 // generate automated column information for Table
 function GenerateTableColumns(data)
 {
+  if (!data.length) return []
   const columns = [];
   const sample = data[0];
   Object.keys(sample).forEach((key)=>{
@@ -90,7 +92,6 @@ class CNVTable extends React.Component {
   }
 
   static getDerivedStateFromProps(newProps, prevState) {
-    console.log(newProps)
     let TableData = GenerateTableData(newProps.variants)
 
     return {
@@ -195,31 +196,29 @@ class CNVTable extends React.Component {
 
 		return TableData && TableColumns && TableData.length > 0 && TableColumns.length > 0
       ? (
-          <div className = "Box">
-            <CheckboxTable
-              ref={(r)=>this.checkboxTable=r}
-              data={TableData}
-              columns={TableColumns}
-              defaultPageSize={this.state.TableData.length}
-              style={{
-                height: "400px"
-              }}
-              className="-striped -highlight"
-              showPagination={false}
-              {...checkboxProps}
-              getTrProps={(state, rowInfo) => {
-                const props = {
-                  onClick: e => {
-                    return this.handleRowClick(rowInfo);
-                  },
-                  style: {
-                    background: this.handleRowBackground(rowInfo),
-                  },
-                };
-                return props;
-              }}
-            />
-          </div>
+          <CheckboxTable
+            ref={(r)=>this.checkboxTable=r}
+            data={TableData}
+            columns={TableColumns}
+            defaultPageSize={this.state.TableData.length}
+            style={{
+              height: "400px"
+            }}
+            className="-striped -highlight"
+            showPagination={false}
+            {...checkboxProps}
+            getTrProps={(state, rowInfo) => {
+              const props = {
+                onClick: e => {
+                  return this.handleRowClick(rowInfo);
+                },
+                style: {
+                  background: this.handleRowBackground(rowInfo),
+                },
+              };
+              return props;
+            }}
+          />
   		  )
       : null
 	}

--- a/src/node_modules/components/CTracksComp/CTracksComp.css
+++ b/src/node_modules/components/CTracksComp/CTracksComp.css
@@ -1,32 +1,52 @@
 
 .TopContainer {
+  width: 100%;
   margin-top: 10px;
   display: flex;
   justify-content: flex-start;
+  flex-flow: row nowrap;
 }
 
 .LeftPanel {
-  flex-direction: row;
-  justify-content: space-around;
+  display: flex;
+  flex-flow: column nowrap;
+  flex: 0 350px;
+}
+
+.PanelBox {
+  width: 350px;
 }
 
 .Box {
-  width: 350px;
-  margin: 10px;
-  margin-bottom: 20px;
-  margin-left: 20px;
   padding: 10px;
+  margin: 10px;
   border: 1px solid #ccc;
   border-radius: 5px;
 }
 
-.RightBox {
-  width: 800px;
-  margin: 10px;
-  /*margin-left: 50px;*/
-  /*padding: 10px;*/
-  border: 1px solid #ccc;
-  border-radius: 5px;
+.RightPanel {
+  min-width: 800px;
+  flex-grow: 1;
+  display: flex;
+  flex-flow: column nowrap;
+}
+
+.Expander {
+  width: 20px;
+  align-self: stretch;
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: center;
+}
+
+.ExpandButton {
+  height: 20px;
+  border-radius: 10px;
+  background-color: black;
+  text-align: center;
+  color: white;
+  font-weight: bolder;
+  cursor: pointer;
 }
 
 .FileReader {

--- a/src/node_modules/components/CTracksComp/CTracksComp.js
+++ b/src/node_modules/components/CTracksComp/CTracksComp.js
@@ -17,6 +17,9 @@ class CTracksComp extends React.Component {
   constructor (props) {
     super(props);
 
+    this.state = {
+      expanded: true
+    }
     this.subscriptions = this.makeSubscriptions()
   }
 
@@ -37,28 +40,42 @@ class CTracksComp extends React.Component {
     ]
   }
 
+  hideTools = () => {
+    this.setState({expanded: false})
+  }
+
+  showTools = () => {
+    this.setState({expanded: true})
+  }
+
   render() {
     return (
       <div className = "TopContainer">
 
-        <div className="LeftPanel">
-          <div className="Box">
+        {!this.state.expanded || <div className="LeftPanel">
+          <div className="Box PanelBox">
             <ChromView chromInfo = {this.props.chromInfo} />
           </div>
-          <div className="Box">
+          <div className="Box PanelBox">
             <ServerAdd/>
           </div>
-          <div className="Box">
+          <div className="Box PanelBox">
             <RegisterURL/>
           </div>
-          <div className="Box">
+          <div className="Box PanelBox">
             <TracksMenu/>
           </div>
+        </div>}
 
+        <div className = "Expander">
+          {this.state.expanded
+            ? <div className = "ExpandButton" onClick={this.hideTools}> &lt; </div>
+            : <div className = "ExpandButton" onClick={this.showTools}> &gt; </div>
+          }
         </div>
 
         <div className = "RightPanel">
-          <div className = "RightBox">
+          <div className = "Box">
             <HiglassUI
               uid = {this.props.uid}
               chromInfo = {this.props.chromInfo}

--- a/src/node_modules/components/CTracksComp/CTracksComp.js
+++ b/src/node_modules/components/CTracksComp/CTracksComp.js
@@ -22,7 +22,8 @@ class CTracksComp extends React.Component {
       expanded: true,
       tracks: ResilientData.tracks(),
       servers: ResilientData.servers(),
-      variants: ResilientData.variants()
+      variants: ResilientData.variants(),
+      tools: ResilientData.tools()
     }
     this.subscriptions = this.makeSubscriptions()
   }
@@ -64,9 +65,17 @@ class CTracksComp extends React.Component {
       hamradio.subscribe(
         'server/add',
         (name, data) => {
-          console.log('server/add in CTracksComp', this.state.servers, data)
           this.setState({
             servers: this.state.servers.concat([data])
+          })
+        }
+      ),
+      hamradio.subscribe(
+        'tools',
+        (name, data) => {
+          console.log('tools', data)
+          this.setState({
+            tools: Object.assign({}, this.state.tools, data)
           })
         }
       )
@@ -98,36 +107,36 @@ class CTracksComp extends React.Component {
     return (
       <div className = "TopContainer">
 
-        {!this.state.expanded || <div className="LeftPanel">
+        {Object.values(this.state.tools).some(item => item) && this.state.expanded && <div className="LeftPanel">
           <div className="Box PanelBox">
-            <ChromView
+            {this.state.tools.zoom && <ChromView
               chromInfo = {this.props.chromInfo}
-            />
+            />}
           </div>
           <div className="Box PanelBox">
-            <ServerAdd
+            {this.state.tools.servers && <ServerAdd
               servers={this.state.servers}
-            />
+            />}
           </div>
           <div className="Box PanelBox">
-            <RegisterURL
+            {this.state.tools.urls && <RegisterURL
               servers={this.state.servers}
-            />
+            />}
           </div>
           <div className="Box PanelBox">
-            <TracksMenu
+            {this.state.tools.tracks && <TracksMenu
               tracks={this.state.tracks}
               servers={this.state.servers}
-            />
+            />}
           </div>
         </div>}
 
-        <div className = "Expander">
+        {Object.values(this.state.tools).some(item => item) && <div className = "Expander">
           {this.state.expanded
             ? <div className = "ExpandButton" onClick={this.hideTools}> &lt; </div>
             : <div className = "ExpandButton" onClick={this.showTools}> &gt; </div>
           }
-        </div>
+        </div>}
 
         <div className = "RightPanel">
           <div className = "Box">
@@ -137,9 +146,13 @@ class CTracksComp extends React.Component {
               tracks={this.state.tracks}
             />
           </div>
-          <CNVTable
-            variants={this.state.variants}
-          />
+          {!!this.state.variants.length &&
+            <div className = "Box">
+              <CNVTable
+                variants={this.state.variants}
+              />
+            </div>
+          }
         </div>
 
       </div>

--- a/src/node_modules/components/CTracksComp/CTracksComp.js
+++ b/src/node_modules/components/CTracksComp/CTracksComp.js
@@ -2,13 +2,14 @@ import React from 'react'
 import hamradio from 'hamradio'
 import axios from 'axios'
 
+import viewconfig from './utils/viewconfig'
 import HiglassUI from './HiglassUI'
 import CNVTable from './CNVTable'
 import ChromView from './ChromView'
 import TracksMenu from './TracksMenu'
 import ServerAdd from './ServerAdd'
 import RegisterURL from './RegisterURL'
-
+import ResilientData from './ResilientData'
 
 import './CTracksComp.css'
 
@@ -18,7 +19,10 @@ class CTracksComp extends React.Component {
     super(props);
 
     this.state = {
-      expanded: true
+      expanded: true,
+      tracks: ResilientData.tracks(),
+      servers: ResilientData.servers(),
+      variants: ResilientData.variants()
     }
     this.subscriptions = this.makeSubscriptions()
   }
@@ -36,8 +40,50 @@ class CTracksComp extends React.Component {
             hamradio.publish('server/updated', server)
           })
         }
+      ),
+      hamradio.subscribe(
+        'track/add',
+        (name, data) => {
+          this.updateTrack(data)
+        }
+      ),
+      hamradio.subscribe(
+        'track/modify',
+        (name, data) => {
+          this.updateTrack(data)
+        }
+      ),
+      hamradio.subscribe(
+        'track/remove',
+        (name, data) => {
+          this.setState({
+            tracks: this.state.tracks.filter(track => track.track.uid !== data)
+          })
+        }
+      ),
+      hamradio.subscribe(
+        'server/add',
+        (name, data) => {
+          console.log('server/add in CTracksComp', this.state.servers, data)
+          this.setState({
+            servers: this.state.servers.concat([data])
+          })
+        }
       )
     ]
+  }
+
+  updateTrack = (newTrack) => {
+    let trackIndex = this.state.tracks.findIndex(track => track.track.uid === newTrack.track.uid)
+    let tracks = (trackIndex === -1)
+      ? [
+          ...this.state.tracks,
+          newTrack
+        ]
+      : this.state.tracks.map((orig, index) => index !== trackIndex ? orig : newTrack)
+    this.setState({
+      tracks: viewconfig.sortTracks(tracks)
+    })
   }
 
   hideTools = () => {
@@ -54,16 +100,25 @@ class CTracksComp extends React.Component {
 
         {!this.state.expanded || <div className="LeftPanel">
           <div className="Box PanelBox">
-            <ChromView chromInfo = {this.props.chromInfo} />
+            <ChromView
+              chromInfo = {this.props.chromInfo}
+            />
           </div>
           <div className="Box PanelBox">
-            <ServerAdd/>
+            <ServerAdd
+              servers={this.state.servers}
+            />
           </div>
           <div className="Box PanelBox">
-            <RegisterURL/>
+            <RegisterURL
+              servers={this.state.servers}
+            />
           </div>
           <div className="Box PanelBox">
-            <TracksMenu/>
+            <TracksMenu
+              tracks={this.state.tracks}
+              servers={this.state.servers}
+            />
           </div>
         </div>}
 
@@ -77,8 +132,9 @@ class CTracksComp extends React.Component {
         <div className = "RightPanel">
           <div className = "Box">
             <HiglassUI
-              uid = {this.props.uid}
-              chromInfo = {this.props.chromInfo}
+              uid={this.props.uid}
+              chromInfo={this.props.chromInfo}
+              tracks={this.state.tracks}
             />
           </div>
           <CNVTable />

--- a/src/node_modules/components/CTracksComp/CTracksComp.js
+++ b/src/node_modules/components/CTracksComp/CTracksComp.js
@@ -137,7 +137,9 @@ class CTracksComp extends React.Component {
               tracks={this.state.tracks}
             />
           </div>
-          <CNVTable />
+          <CNVTable
+            variants={this.state.variants}
+          />
         </div>
 
       </div>

--- a/src/node_modules/components/CTracksComp/HiglassUI.css
+++ b/src/node_modules/components/CTracksComp/HiglassUI.css
@@ -1,7 +1,6 @@
 
 .higlass{
-
-  width: 800px;
+  width: 100%;
   padding-top:10px;
   padding-bottom:10px;
   padding: 0px;

--- a/src/node_modules/components/CTracksComp/HiglassUI.js
+++ b/src/node_modules/components/CTracksComp/HiglassUI.js
@@ -17,21 +17,33 @@ class HiglassUI extends React.Component {
 
     this.publishLocation = this.publishLocation.bind(this);
 
+    let metaViewConfig = {uid: props.uid, tracks: {}}
     this.state = {
-      metaViewConfig: {uid: props.uid, tracks: {}}
+      metaViewConfig
     }
+    this.prevMeta = JSON.stringify(metaViewConfig)
+    
     this.subscriptions = this.makeSubscriptions()
+  }
 
-    this.prevViewConfig = JSON.stringify(this.state.metaViewConfig)
+  static getDerivedStateFromProps(nextProps, prevState) {
+    let metaViewConfig = prevState.metaViewConfig && prevState.metaViewConfig.uid === nextProps.uid
+      ? {...prevState.metaViewConfig, tracks: {}}
+      : {uid: nextProps.uid, tracks: {}}
+
+    nextProps.tracks.forEach(track => viewconfig.addTrack(metaViewConfig, track))
+    return {
+      metaViewConfig
+    }
   }
 
   shouldComponentUpdate(newProps, newState) {
-    if (this.prevViewConfig === JSON.stringify(newState.metaViewConfig)) {
-      return false;
+    if (this.prevMeta === JSON.stringify(newState.metaViewConfig)) {
+      return false
     }
 
-    this.prevViewConfig = JSON.stringify(newState.metaViewConfig);
-    return true;
+    this.prevMeta = JSON.stringify(newState.metaViewConfig)
+    return true
   }
 
   componentWillUnmount() {
@@ -69,30 +81,6 @@ class HiglassUI extends React.Component {
               metaViewConfig: viewconfig.setOverlay(this.state.metaViewConfig, highlights)
             })
           }
-        }
-      ),
-      hamradio.subscribe(
-        'track/add', //global channel or focus
-        (name, data) => {
-          this.setState({
-            metaViewConfig: viewconfig.addTrack(this.state.metaViewConfig, data)
-          })
-        }
-      ),
-      hamradio.subscribe(
-        'track/remove', //global channel or focus
-        (name, data) => {
-          this.setState({
-            metaViewConfig: viewconfig.removeTrack(this.state.metaViewConfig, data)
-          })
-        }
-      ),
-      hamradio.subscribe(
-        'track/modify', //global channel or focus
-        (name, data) => {
-          this.setState({
-            metaViewConfig: viewconfig.modifyTrack(this.state.metaViewConfig, data)
-          })
         }
       )
     ]

--- a/src/node_modules/components/CTracksComp/RegisterURL.js
+++ b/src/node_modules/components/CTracksComp/RegisterURL.js
@@ -21,10 +21,6 @@ class RegisterURL extends React.Component {
     }
   }
 
-  componentWillUnmount() {
-    this.subscriptions.forEach(sub => sub.unsubscribe())
-  }
-
   serverElement = (server, order) => {
     return {
       label: server.name || server.api,

--- a/src/node_modules/components/CTracksComp/RegisterURL.js
+++ b/src/node_modules/components/CTracksComp/RegisterURL.js
@@ -12,13 +12,10 @@ class RegisterURL extends React.Component {
   constructor(props) {
     super(props)
 
-    this.subscriptions = this.makeSubscriptions()
-
     this.state = {
-      servers: [],
       url: '',
       name: '',
-      server: {value: null, label:'', api: ''},
+      server: this.props.servers.length ? this.serverElement(this.props.servers[0], 0) : {value: null, label:'', api: ''},
       datatype: {value: 'vector', label: 'vector'},
       filetype: {value: 'hitile', label: 'hitile'}
     }
@@ -28,23 +25,12 @@ class RegisterURL extends React.Component {
     this.subscriptions.forEach(sub => sub.unsubscribe())
   }
 
-  makeSubscriptions = () => {
-    return [
-      hamradio.subscribe(
-        'server/add',
-        (name, server) => {
-          let servers = this.state.servers.concat([{
-            label: server.name || server.api,
-            value: this.state.servers.length,
-            api: server.api
-          }])
-          this.setState({
-            servers: servers,
-            server: servers[0]
-          })
-        }
-      )
-    ]
+  serverElement = (server, order) => {
+    return {
+      label: server.name || server.api,
+      value: order,
+      api: server.api
+    }
   }
 
   done = () => {
@@ -74,7 +60,7 @@ class RegisterURL extends React.Component {
         <LabelLayout label="Registry Server"
           inner=<Selector
             value={this.state.serverIndex}
-            options={this.state.servers}
+            options={this.props.servers.map((server, index) => this.serverElement(server, index))}
             onChange={val => this.setState({serverIndex: val})}
           />
         />

--- a/src/node_modules/components/CTracksComp/ResilientData.js
+++ b/src/node_modules/components/CTracksComp/ResilientData.js
@@ -1,0 +1,49 @@
+import hamradio from 'hamradio'
+
+let servers = []
+let tracks = []
+let variants = []
+
+let subscriptions = []
+
+export default {
+  initialize (prefix) {
+    servers = JSON.parse((sessionStorage.getItem(`${prefix}/servers`))) || []
+    tracks = JSON.parse((sessionStorage.getItem(`${prefix}/tracks`))) || []
+    variants = JSON.parse((sessionStorage.getItem(`${prefix}/variants`))) || []
+
+    subscriptions.forEach(sub => sub.unsubscribe())
+    subscriptions = [
+      hamradio.subscribe('track/add', (name, data) => {
+        tracks.push(data)
+        sessionStorage.setItem(`${prefix}/tracks`, JSON.stringify(tracks))
+      }),
+      hamradio.subscribe('track/modify', (name, data) => {
+        tracks = tracks.filter(track => data.track.uid !== track.track.uid)
+        tracks.push(data)
+        sessionStorage.setItem(`${prefix}/tracks`, JSON.stringify(tracks))
+      }),
+      hamradio.subscribe('track/remove', (name, data) => {
+        tracks = tracks.filter(track => data !== track.track.uid)
+        sessionStorage.setItem(`${prefix}/tracks`, JSON.stringify(tracks))
+      }),
+      hamradio.subscribe('server/add', (name, data) => {
+        servers.push(data)
+        sessionStorage.setItem(`${prefix}/servers`, JSON.stringify(servers))
+      }),
+      hamradio.subscribe('cTracks/variants', (name, data) => {
+        variants = data
+        sessionStorage.setItem(`${prefix}/variants`, JSON.stringify(data))
+      })
+    ]
+  },
+  servers () {
+    return [...servers]
+  },
+  tracks () {
+    return [...tracks]
+  },
+  variants () {
+    return [...variants]
+  }
+}

--- a/src/node_modules/components/CTracksComp/ResilientData.js
+++ b/src/node_modules/components/CTracksComp/ResilientData.js
@@ -3,6 +3,12 @@ import hamradio from 'hamradio'
 let servers = []
 let tracks = []
 let variants = []
+let tools = {
+  zoom: true,
+  servers: true,
+  urls: true,
+  tracks: true
+}
 
 let subscriptions = []
 
@@ -11,6 +17,12 @@ export default {
     servers = JSON.parse((sessionStorage.getItem(`${prefix}/servers`))) || []
     tracks = JSON.parse((sessionStorage.getItem(`${prefix}/tracks`))) || []
     variants = JSON.parse((sessionStorage.getItem(`${prefix}/variants`))) || []
+    tools = JSON.parse((sessionStorage.getItem(`${prefix}/tools`))) || {
+      zoom: true,
+      servers: true,
+      urls: true,
+      tracks: true
+    }
 
     subscriptions.forEach(sub => sub.unsubscribe())
     subscriptions = [
@@ -34,6 +46,10 @@ export default {
       hamradio.subscribe('cTracks/variants', (name, data) => {
         variants = data
         sessionStorage.setItem(`${prefix}/variants`, JSON.stringify(data))
+      }),
+      hamradio.subscribe('tools', (name, data) => {
+        tools = Object.assign({}, tools, data)
+        sessionStorage.setItem(`${prefix}/tools`, JSON.stringify(data))
       })
     ]
   },
@@ -45,5 +61,8 @@ export default {
   },
   variants () {
     return [...variants]
+  },
+  tools () {
+    return {...tools}
   }
 }

--- a/src/node_modules/components/CTracksComp/ServerAdd.js
+++ b/src/node_modules/components/CTracksComp/ServerAdd.js
@@ -19,10 +19,6 @@ class ServerAdd extends React.Component {
     }
   }
 
-  componentWillUnmount() {
-    this.subscriptions.forEach(sub => sub.unsubscribe())
-  }
-
   addServer = () => {
     axios.get(`${this.state.addAPI}/tilesets`)
       .then(response => {

--- a/src/node_modules/components/CTracksComp/ServerAdd.js
+++ b/src/node_modules/components/CTracksComp/ServerAdd.js
@@ -12,10 +12,7 @@ class ServerAdd extends React.Component {
   constructor (props) {
     super(props)
 
-    this.subscriptions = this.makeSubscriptions()
-
     this.state = {
-      servers: [],
       addName: '',
       addAPI: '',
       error: null
@@ -24,19 +21,6 @@ class ServerAdd extends React.Component {
 
   componentWillUnmount() {
     this.subscriptions.forEach(sub => sub.unsubscribe())
-  }
-
-  makeSubscriptions = () => {
-    return [
-      hamradio.subscribe(
-        'server/add',
-        (name, server) => {
-          this.setState({
-            servers: this.state.servers.concat([server])
-          })
-        }
-      )
-    ]
   }
 
   addServer = () => {
@@ -61,8 +45,8 @@ class ServerAdd extends React.Component {
       <div>
         <label>Servers</label>
         <ul>
-          {this.state.servers.length
-            ? this.state.servers.map(server => server.name
+          {this.props.servers.length
+            ? this.props.servers.map(server => server.name
               ? <li key={server.api}>{server.name}: {server.api}</li>
               : <li key={server.api}>{server.api}</li>
             )

--- a/src/node_modules/components/CTracksComp/TracksMenu.js
+++ b/src/node_modules/components/CTracksComp/TracksMenu.js
@@ -1,27 +1,24 @@
 import React from 'react'
 import hamradio from 'hamradio'
 
-import viewconfig from './utils/viewconfig'
 import CheckBox from './CheckBox'
 import TrackSpec from './TrackSpec'
 import TrackAdd from './TrackAdd'
+
 import './TracksMenu.css'
 
 
 class TracksMenu extends React.Component {
   constructor (props) {
     super(props);
+    console.log(props)
 
     this.toggleCheckBoxGlobal = this.toggleCheckBoxGlobal.bind(this);
     this.toggleCheckBoxFocus = this.toggleCheckBoxFocus.bind(this);
     this.createCheckBox = this.createCheckBox.bind(this);
     this.createCheckBoxes = this.createCheckBoxes.bind(this);
 
-    this.subscriptions = this.makeSubscriptions()
-
     this.state = {
-      tracks: [],
-      servers: [],
       editTrack: null
     }
 	}
@@ -30,52 +27,12 @@ class TracksMenu extends React.Component {
     this.subscriptions.forEach(sub => sub.unsubscribe())
   }
 
-  updateTrack = (newTrack) => {
-    let trackIndex = this.state.tracks.findIndex(track => track.track.uid === newTrack.track.uid)
-    let tracks = (trackIndex === -1)
-      ? [
-          ...this.state.tracks,
-          newTrack
-        ]
-      : this.state.tracks.map((orig, index) => index !== trackIndex ? orig : newTrack)
-    this.setState({
-      tracks: viewconfig.sortTracks(tracks)
-    })
-  }
-
-  makeSubscriptions = () => {
-    return [
-      hamradio.subscribe(
-        'track/add',
-        (name, data) => {
-          this.updateTrack(data)
-        }
-      ),
-      hamradio.subscribe(
-        'track/remove',
-        (name, data) => {
-          this.setState({
-            tracks: this.state.tracks.filter(track => track.track.uid !== data)
-          })
-        }
-      ),
-      hamradio.subscribe(
-        'server/add',
-        (name, data) => {
-          this.setState({
-            servers: this.state.servers.concat([data])
-          })
-        }
-      )
-    ]
-  }
-
   toggleCheckBoxGlobal (name) {
-    for (var i = 0; i < this.state.tracks.length; i++) {
-      if (this.state.tracks[i].track.name === name) {
+    for (var i = 0; i < this.props.tracks.length; i++) {
+      if (this.props.tracks[i].track.name === name) {
         let track = {
-          ...this.state.tracks[i],
-          global: !this.state.tracks[i].global
+          ...this.props.tracks[i],
+          global: !this.props.tracks[i].global
         }
         hamradio.publish('track/modify', track)
         break;
@@ -84,11 +41,11 @@ class TracksMenu extends React.Component {
   }
 
   toggleCheckBoxFocus (name) {
-    for (var i = 0; i < this.state.tracks.length; i++) {
-      if (this.state.tracks[i].track.name === name) {
+    for (var i = 0; i < this.props.tracks.length; i++) {
+      if (this.props.tracks[i].track.name === name) {
         let track = {
-          ...this.state.tracks[i],
-          focus: !this.state.tracks[i].focus
+          ...this.props.tracks[i],
+          focus: !this.props.tracks[i].focus
         }
         hamradio.publish('track/modify', track)
         break;
@@ -132,7 +89,7 @@ class TracksMenu extends React.Component {
   }
 
   createCheckBoxes () {
-  	return this.state.tracks.length ? (<table>
+  	return this.props.tracks.length ? (<table>
       <tbody>
         <tr>
           <td><label className="CheckBoxTitle">Global</label></td>
@@ -140,7 +97,7 @@ class TracksMenu extends React.Component {
           <td><label className="CheckBoxTitle">Track name</label></td>
           <td><label className="CheckBoxTitle"></label></td>
         </tr>
-        {this.state.tracks.map(this.createCheckBox)}
+        {this.props.tracks.map(this.createCheckBox)}
       </tbody>
     </table>) : null
 }
@@ -151,15 +108,15 @@ class TracksMenu extends React.Component {
   			<label>Tracks</label>
         {this.createCheckBoxes()}
         <TrackAdd
-          servers={this.state.servers}
-          order={this.state.tracks.length}
-          excludeTracks={this.state.tracks.map(track => track.track.tilesetUid)}
+          servers={this.props.servers}
+          order={this.props.tracks.length}
+          excludeTracks={this.props.tracks.map(track => track.track.tilesetUid)}
         />
       </div>
 		) : (
       <div>
   			<label>Higlass - Edit Track</label>
-        <TrackSpec track={this.state.editTrack} servers={this.state.servers} done={() => this.editTrack(null)}/>
+        <TrackSpec track={this.state.editTrack} servers={this.props.servers} done={() => this.editTrack(null)}/>
       </div>
     )
 	}

--- a/src/node_modules/components/CTracksComp/TracksMenu.js
+++ b/src/node_modules/components/CTracksComp/TracksMenu.js
@@ -11,7 +11,6 @@ import './TracksMenu.css'
 class TracksMenu extends React.Component {
   constructor (props) {
     super(props);
-    console.log(props)
 
     this.toggleCheckBoxGlobal = this.toggleCheckBoxGlobal.bind(this);
     this.toggleCheckBoxFocus = this.toggleCheckBoxFocus.bind(this);
@@ -22,10 +21,6 @@ class TracksMenu extends React.Component {
       editTrack: null
     }
 	}
-
-  componentWillUnmount() {
-    this.subscriptions.forEach(sub => sub.unsubscribe())
-  }
 
   toggleCheckBoxGlobal (name) {
     for (var i = 0; i < this.props.tracks.length; i++) {

--- a/src/node_modules/components/CTracksComp/utils/tracks.js
+++ b/src/node_modules/components/CTracksComp/utils/tracks.js
@@ -21,7 +21,6 @@ function track (overrides, options) {
       tilesetUid: "",
       uid: "",
       type: "horizontal-point",
-      width: 770,
       height: 38,
       position: "top"
     },
@@ -39,7 +38,6 @@ const chromosomeAxisTrack = {
   uid: "bpRZDog1QQuZ7DmLfsKwXw",
   type: "horizontal-chromosome-labels",
   options: {},
-  width: 770,
   height: 30,
   position: "top"
 }
@@ -59,7 +57,6 @@ const geneAnnotationsHG19Track = {
     trackBorderColor: "black",
     name: "Gene Annotations (hg19)"
   },
-  width: 20,
   height: 55,
   position: "top"
 }

--- a/src/node_modules/components/CTracksComp/utils/viewconfig.js
+++ b/src/node_modules/components/CTracksComp/utils/viewconfig.js
@@ -32,7 +32,6 @@ function globalTrackTemplate (track) {
     type: "combined",
     uid: track.uid,
     height: track.height,
-    width: track.width,
     position: 'top',
     options: {},
     contents: [


### PR DESCRIPTION
Specifically, a signal can be sent to turn on and off the various tools in the toolbar. If all tools are off, the entire left panel is not rendered.

Alternately, the left panel can now be collapsed and hidden from view.

Work incident to collapsing the side panel resulted in allowing us to remember certain critical data over refreshes.