### PR TITLE
Use HiGlassComponent directly to avoid a race condition

### DIFF
--- a/src/node_modules/components/CTracksComp/HiglassUI.js
+++ b/src/node_modules/components/CTracksComp/HiglassUI.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import * as hglib from 'higlass';
+import { HiGlassComponent } from 'higlass';
 import hamradio from 'hamradio'
 import './HiglassUI.css'
 
@@ -22,7 +22,7 @@ class HiglassUI extends React.Component {
       metaViewConfig
     }
     this.prevMeta = JSON.stringify(metaViewConfig)
-    
+
     this.subscriptions = this.makeSubscriptions()
   }
 
@@ -86,26 +86,18 @@ class HiglassUI extends React.Component {
     ]
   }
 
-  launchHgLib() {
-    return (element) => {
-      if (element && this.state.metaViewConfig) {
-        let api = hglib.viewer(
-          element,
-          viewconfig.generateViewConfig(this.state.metaViewConfig),
-          { bounded: false }
-        );
-        this.api = api
-
-        api.on('location', this.publishLocation, `${this.state.metaViewConfig.uid}-focus`)
-      }
-    }
+  initHg = ({ api }) => {
+    this.api = api;
+    api.on('location', this.publishLocation, `${this.state.metaViewConfig.uid}-focus`);
   }
 
   render () {
   	return (
-        <div className = "higlass"
-          ref={this.launchHgLib()}>
-        </div>
+      <HiGlassComponent
+        ref={this.initHg}
+        options={{ bounded: false }}
+        viewConfig={viewconfig.generateViewConfig(this.state.metaViewConfig)}
+      />
 		)
   }
 }


### PR DESCRIPTION
This PR replaces `hglib.viewer` with `HiGlassComponent` to avoid a race condition potentially caused by `ReactDOM.render` in `hglib.viewer`'s `launch` function.