### PR TITLE
Remove power-user features from higlass ui.

### DIFF
--- a/src/node_modules/components/CTracksComp/utils/viewconfig.js
+++ b/src/node_modules/components/CTracksComp/utils/viewconfig.js
@@ -1,7 +1,7 @@
 import tracks from './tracks'
 
 const emptyViewConfig = {
-  editable: true,
+  editable: false,
   zoomFixed: false,
   trackSourceServers: ["http://higlass.io/api/v1"],
   exportViewUrl: "http://localhost:8989/api/v1/viewconfs/",
@@ -61,6 +61,9 @@ function globalView (uid, globalTracks) {
     uid: `${uid}-global`,
     initialXDomain: zoomFullChrom,
     initialYDomain: zoomFullChrom,
+    xDomainLimits: zoomFullChrom,
+    yDomainLimits: zoomFullChrom,
+    zoomLimits: [1, 1],
     genomePositionSearchBox,
     layout: {
       w: 12,


### PR DESCRIPTION
This removes the ability to directly change the higlass tracks, and to zoom or pan the global view.